### PR TITLE
Allow support for non-standard characters

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -76,7 +76,7 @@
       , padding: CryptoJS.pad.NoPadding
     }
     var aesctr = CryptoJS.AES.encrypt(
-        CryptoJS.enc.Latin1.parse(msg)
+        CryptoJS.enc.Utf8.parse(msg)
       , CryptoJS.enc.Latin1.parse(c)
       , opts
     )
@@ -96,7 +96,7 @@
       , CryptoJS.enc.Latin1.parse(c)
       , opts
     )
-    return aesctr.toString(CryptoJS.enc.Latin1)
+    return aesctr.toString(CryptoJS.enc.Utf8)
   }
 
   HLP.multPowMod = function (a, b, c, d, e) {


### PR DESCRIPTION
Modified some encodings from Latin1 to Utf8 (for AES message encryption/decryption specifically) so that messages containing nonstandard characters (يا هلا يا حبيبي خذني إلى القمر) are parsed correctly in OTR chats.
