### PR TITLE
plaintext encoding issue & handle TLV type 1

### DIFF
--- a/lib/otr.js
+++ b/lib/otr.js
@@ -396,6 +396,12 @@
         type = HLP.unpackSHORT(tlvs.substr(0, 2))
         len = HLP.unpackSHORT(tlvs.substr(2, 2))
 
+        //Disconnected
+        if(type === 1){
+          this.msgstate = CONST.MSGSTATE_FINISHED
+          this.uicb(null, 'Your buddy closed the private connection! You should do the same.')
+        }
+
         // TODO: handle pathological cases better
         if (!len || (len + 4) > tlvs.length) break
 


### PR DESCRIPTION
1) plaintext messages with german letters had a encoding issue. "äöüß" looked like "Ã¤Ã¶Ã¼Ã".

2) Handle TLV type 1
