### PR TITLE
Don't use relative AMD module paths and make explicit bigint's dependency on crypto.

### DIFF
--- a/build/dep/bigint.js
+++ b/build/dep/bigint.js
@@ -2,7 +2,9 @@
 
   var Salsa20, crypto
   if (typeof define === 'function' && define.amd) {
-    define(['./salsa20'], factory.bind(root, root.crypto))
+    define(['crypto', 'salsa20'], function (crypto, salsa) {
+      return factory.call(root, root.crypto, salsa)
+    });
   } else if (typeof module !== 'undefined' && module.exports) {
     Salsa20 = require('./salsa20.js')
     crypto = require('crypto')

--- a/build/otr.js
+++ b/build/otr.js
@@ -13,9 +13,9 @@
 
   if (typeof define === 'function' && define.amd) {
     define([
-        "./dep/bigint"
-      , "./dep/crypto"
-      , "./dep/eventemitter"
+        "bigint"
+      , "crypto"
+      , "eventemitter"
     ], function (BigInt, CryptoJS, EventEmitter) {
       var root = {
           BigInt: BigInt


### PR DESCRIPTION
Hi @arlolra

Thank you for this excellent library. I'm using it to provide OTR functionality in converse.js. 
I would appreciate it if you mentioned converse.js under the list of programs using OTR.js

This pull request contains two changes.
- **Make explicit bigint's dependency on crypto** (See line 5 in bigint.js)

This is the most important change for me. I'm using PhantomJS/Jasmine for tests and without this change they break because _root.crypto_ is undefined.
- **Don't use relative paths for AMD modules.**

I'm not an AMD/require.js expert but it appears to me that using relative paths to AMD modules in the _define_ call is an anti-pattern.

The reason for this is that converse.js is now forced to include OTR.js also via a relative path and this makes it difficult for consumers of converse.js to integrate it into their AMD/require.js projects, because they now need to maintain the same filesystem layout expected by both converse.js and OTR.js.

Instead, how I think it needs to be done is that require.js's config option must be used to configure the relative paths, and then in the _define_ call only the module name is used. Here is for example how converse.js configures the paths: https://github.com/jcbrand/converse.js/blob/master/main.js

Link to require.js's docs on _config_: http://requirejs.org/docs/api.html#config

The require.js config call is separate from any modules and is project specific. This means that integrators can configure the paths specifically for their own project and don't need to maintain a specific filesystem structure.

Thanks
JC
