### PR TITLE
Bugfix in BigInt.js. Need to pass in empty list of AMD dependencies.

### DIFF
--- a/vendor/bigint.js
+++ b/vendor/bigint.js
@@ -1,7 +1,7 @@
 ;(function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(factory.bind(root, root.crypto || root.msCrypto))
+    define([], factory.bind(root, root.crypto || root.msCrypto))
   } else if (typeof module !== 'undefined' && module.exports) {
     module.exports = factory(require('crypto'))
   } else {


### PR DESCRIPTION
Otherwise Almond.js (0.2.9) fails with:
    `TypeError: Cannot call method 'splice' of undefined`
