### PR TITLE
add option to attach meta data to incoming messages

### DIFF
--- a/lib/otr.js
+++ b/lib/otr.js
@@ -590,7 +590,7 @@
     if (msg) this.io(msg, meta)
   }
 
-  OTR.prototype.receiveMsg = function (msg) {
+  OTR.prototype.receiveMsg = function (msg, meta) {
 
     // parse type
     msg = Parse.parseMsg(this, msg)
@@ -641,7 +641,7 @@
           this.doAKE(msg)
     }
 
-    if (msg.msg) this.trigger('ui', [msg.msg, !!msg.encrypted])
+    if (msg.msg) this.trigger('ui', [msg.msg, !!msg.encrypted, meta])
   }
 
   OTR.prototype.checkInstanceTags = function (it) {

--- a/readme.md
+++ b/readme.md
@@ -80,9 +80,10 @@ For each user you're communicating with, instantiate an OTR object.
 
     var buddy = new OTR(options)
 
-    buddy.on('ui', function (msg, encrypted) {
+    buddy.on('ui', function (msg, encrypted, meta) {
       console.log("message to display to the user: " + msg)
       // encrypted === true, if the received msg was encrypted
+      console.log("(optional) with receiveMsg attached meta data: " + meta)
     })
 
     buddy.on('io', function (msg, meta) {
@@ -99,7 +100,8 @@ For each user you're communicating with, instantiate an OTR object.
 method.
 
     var rcvmsg = "Message from buddy."
-    buddy.receiveMsg(rcvmsg)
+    var meta = "optional some meta data, like delay"
+    buddy.receiveMsg(rcvmsg, meta)
 
 **Send a message to buddy**: Pass the message to the `sendMsg` method.
 

--- a/test/spec/unit/otr.js
+++ b/test/spec/unit/otr.js
@@ -740,4 +740,18 @@ describe('OTR', function () {
 
   })
 
+  it('should passthrough meta data for received message', function(done) {
+     var m1 = 'text message'
+     var m2 = 'meta data'
+
+     var userA = new OTR({ priv: keys.userA })
+     userA.on('ui', function (msg, encrypted, meta) {
+        assert.equal(msg, m1)
+        assert.equal(meta, m2)
+        done()
+     })
+
+     userA.receiveMsg(m1, m2)        
+  })
+
 })


### PR DESCRIPTION
I want to merge an enhanced version of sualko/jsxc#120 and therefore I need to attach a receiving time to messages, because they could be [delayed](http://xmpp.org/extensions/xep-0203.html).