### PR TITLE
consistent behavior for endOtr

### DIFF
--- a/lib/otr.js
+++ b/lib/otr.js
@@ -244,6 +244,9 @@
         var elem = self.outgoing.shift(), cb = null
         if (elem.meta instanceof OTRCB) {
           cb = elem.meta.cb
+          // otherwise if original msg param had > 1 messages
+          // callback will get called multiple times
+          elem.meta.cb = null
           elem.meta = null
         }
         self.trigger('io', [elem.msg, elem.meta])

--- a/lib/otr.js
+++ b/lib/otr.js
@@ -723,6 +723,8 @@
         this.sm = null
       }
     }
+    else setImmediate(cb)
+
     this.msgstate = CONST.MSGSTATE_PLAINTEXT
     this.receivedPlaintext = false
     this.trigger('status', [CONST.STATUS_END_OTR])


### PR DESCRIPTION
consistent behavior: call the callback asynchronously regardless of msgstate

prevent multiple calls: sometimes the msg argument to io(msg, meta) has 2 messages. If meta has a cb property, this results in the callback being called multiple times. "elem.meta = null" is not enough, because the other message is pointing to the same meta object and will call the same callback