### PR TITLE
handle already defined crypto object in webworker

### DIFF
--- a/lib/dsa-webworker.js
+++ b/lib/dsa-webworker.js
@@ -3,10 +3,9 @@
 
   root.OTR = {}
   root.DSA = {}
-  root.crypto = {
-    randomBytes: function () {
-      throw new Error("Haven't seeded yet.")
-    }
+  if (!root.crypto) root.crypto = {}
+  root.crypto.randomBytes = function () {
+    throw new Error("Haven't seeded yet.")
   }
 
   // default imports


### PR DESCRIPTION
With the latest version of Chrome (43.0.2357.124 (64-bit)) I get an error in line 7 for dsa-webworker.js:

```
Uncaught TypeError: Cannot set property crypto of #<WorkerGlobalScope> which has only a getter
```

<code>Console.log</code> for <code>root.crypto</code> prints:

```
Crypto {}
  subtle: SubtleCrypto
```

Patch tested in Chrome 43, Chromium 41.0.2272.76 and Firefox 38.0.