### PR TITLE
Replace Travis CI's unstable 0.11 version of Node to stable 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "0.11"
+  - "0.12"
   - "0.10.30"
 
 before_install:


### PR DESCRIPTION
I am also tempted to add [`iojs`](http://docs.travis-ci.com/user/languages/javascript-with-nodejs/). [Node 4.0.0 just got released](https://nodejs.org/en/blog/release/v4.0.0/). They merged Node and iojs, and the codebase is apparently very close to iojs, so I'm thinking transitioning to Node 4.0.0 will be easier if things pass with iojs...