### PR TITLE
Add Node 4 support to Travis CI and allows it to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: node_js
 
 node_js:
+  - "4.0.0"
   - "0.12"
   - "0.10.30"
+
+matrix:
+  allow_failures:
+  - node_js: "4.0.0"
 
 before_install:
   - "sudo apt-get update"


### PR DESCRIPTION
Allows that configuration to fail as I didn't do any test myself.
It will only be safe to remove this once thorough tests are done.